### PR TITLE
Auth 모듈 개발, 각종 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG ENVIRONMENT
 ENV SPRING_PROFILES_ACTIVE=${ENVIRONMENT}
 
 EXPOSE 8080
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","/app.jar","-Dspring.profiles.active=prod"]
 
 #RUN ./gradlew build
 #ARG JAR_FILE=build/libs/*.jar

--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,17 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'mysql:mysql-connector-java'
 
+	/**
+	 * mapstruct
+	 * Entity -> Dto 나 그 반대로 비꾸어주는 역할을 하는 라이브러리
+	 */
+//	implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+//	annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
+
     // lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	implementation group: 'org.projectlombok', name: 'lombok-mapstruct-binding', version: '0.2.0'
 
 	// 스프링 시큐리티, jwt
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	// jpa, mysql
+	// jpa, mysql, Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'mysql:mysql-connector-java'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	/**
 	 * mapstruct

--- a/src/main/java/bis/stock/back/domain/auth/AuthController.java
+++ b/src/main/java/bis/stock/back/domain/auth/AuthController.java
@@ -7,6 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 @RestController
@@ -22,16 +25,17 @@ public class AuthController {
     }
 
     // 로그인
-    @PostMapping("login")
-    public ResponseEntity<AccessTokenDto> login(@RequestBody LoginDto loginDto) {
+    @PostMapping("/login")
+    public ResponseEntity<AccessTokenDto> login(@RequestBody LoginDto loginDto,
+                                                HttpServletResponse res) {
 
-        return ResponseEntity.ok(new AccessTokenDto());
+        return ResponseEntity.ok(authService.login(loginDto, res));
     }
 
     // 재발급 (refresh 토큰을 이용해 access 토큰 재발급)
     @PostMapping("reissue")
-    public ResponseEntity<AccessTokenDto> reissue() {
+    public ResponseEntity<AccessTokenDto> reissue(HttpServletRequest req, HttpServletResponse res) {
 
-        return ResponseEntity.ok(new AccessTokenDto());
+        return ResponseEntity.ok(authService.reissue(req, res));
     }
 }

--- a/src/main/java/bis/stock/back/domain/auth/AuthController.java
+++ b/src/main/java/bis/stock/back/domain/auth/AuthController.java
@@ -1,0 +1,37 @@
+package bis.stock.back.domain.auth;
+
+import bis.stock.back.domain.auth.dto.AccessTokenDto;
+import bis.stock.back.domain.auth.dto.JoinDto;
+import bis.stock.back.domain.auth.dto.LoginDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+
+    // 회원가입
+    @PostMapping("/join")
+    public ResponseEntity<Long> join(@RequestBody JoinDto joinDto) {
+
+        return ResponseEntity.ok(authService.join(joinDto));
+    }
+
+    // 로그인
+    @PostMapping("login")
+    public ResponseEntity<AccessTokenDto> login(@RequestBody LoginDto loginDto) {
+
+        return ResponseEntity.ok(new AccessTokenDto());
+    }
+
+    // 재발급 (refresh 토큰을 이용해 access 토큰 재발급)
+    @PostMapping("reissue")
+    public ResponseEntity<AccessTokenDto> reissue() {
+
+        return ResponseEntity.ok(new AccessTokenDto());
+    }
+}

--- a/src/main/java/bis/stock/back/domain/auth/AuthService.java
+++ b/src/main/java/bis/stock/back/domain/auth/AuthService.java
@@ -1,13 +1,25 @@
 package bis.stock.back.domain.auth;
 
+import bis.stock.back.domain.auth.dto.AccessTokenDto;
 import bis.stock.back.domain.auth.dto.JoinDto;
+import bis.stock.back.domain.auth.dto.LoginDto;
 import bis.stock.back.domain.user.User;
 import bis.stock.back.domain.user.UserRepository;
 import bis.stock.back.domain.user.UserRole;
-import javassist.NotFoundException;
+import bis.stock.back.global.config.security.JwtTokenProvider;
+import bis.stock.back.global.exception.ForbiddenException;
+import bis.stock.back.global.exception.NotFoundException;
+import bis.stock.back.global.util.CookieUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.Collections;
 
 @RequiredArgsConstructor
@@ -15,17 +27,101 @@ import java.util.Collections;
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CookieUtil cookieUtil;
+    private final UserDetailsService userDetailsService;
 
     public Long join(JoinDto joinDto) {
 
-        try {
-            return userRepository.save(User.builder()
-                    .email(joinDto.getEmail())
-                    .password(joinDto.getPassword())
-                    .role(UserRole.ROLE_USER)
-                    .build()).getId();
-        } catch (Exception e) {
-            throw e;
+        // 가입된 사용자인지 체크
+        if(userRepository.findByEmail(joinDto.getEmail()).orElse(null) != null) {
+            throw new NotFoundException("이미 존재하는 email입니다.");
+        }
+
+        return userRepository.save(User.builder()
+                .email(joinDto.getEmail())
+                .password(passwordEncoder.encode(joinDto.getPassword()))
+                .nickname(joinDto.getNickname())
+                .cash(0L)
+                .roles(Collections.singletonList(UserRole.ROLE_USER))
+                .build()).getId();
+    }
+
+    public AccessTokenDto login(LoginDto loginDto, HttpServletResponse res) {
+
+        // 로그인한 정보로 user 엔티티 가져오기
+        User user = userRepository.findByEmail(loginDto.getEmail())
+                .orElseThrow(() -> new InternalAuthenticationServiceException("가입되지 않은 email입니다."));
+
+        if(!passwordEncoder.matches(loginDto.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("잘못된 비밀번호 입니다.");
+        }
+
+        // user 엔티티의 정보로 jwt 토큰(문자열) 만들기
+        String accessTokenJwt = jwtTokenProvider.createAccessToken(user.getUsername(), user.getRoles());
+        String refreshTokenJwt = jwtTokenProvider.createRefreshToken(user.getUsername(), user.getRoles());
+
+        // jwt 토큰을 쿠키로 만들기
+        Cookie accessToken = cookieUtil.createCookie("accessToken",
+                accessTokenJwt, jwtTokenProvider.ACCESS_TOKEN_VALID_TIME, "/");
+        Cookie refreshToken = cookieUtil.createCookie("refreshToken",
+                refreshTokenJwt, jwtTokenProvider.REFRESH_TOKEN_VALID_TIME, "/auth/reissue");
+
+        // servlet 응답에 쿠키 추가
+        res.addCookie(accessToken);
+        res.addCookie(refreshToken);
+
+        /**
+         * 로그인할 때 redis에 refresh 토큰을 저장해 놓는다.
+         * 이 때 refresh 토큰의 만료시간을 함께 설정해서 만료시간이 끝나면 자동으로 사라지게 함.
+         * 이후 access 토큰 재발급때 확인하고 재발급함.
+         */
+//        redisUtil.setDataExpire(refreshTokenJwt, member.getEmail(), jwtTokenProvider.REFRESH_TOKEN_VALID_TIME);
+        return AccessTokenDto.builder().accessToken(accessTokenJwt).build();
+    }
+
+    public AccessTokenDto reissue(HttpServletRequest req, HttpServletResponse res) {
+
+        // Http 요청에서부터 "refreshToken"이름의 쿠키를 받아옴.
+        Cookie refreshToken;
+        refreshToken = cookieUtil.getCookie(req, "refreshToken");
+
+        // 쿠키가 없으면 만료되었다는 의미이므로 Exception
+        if(refreshToken == null) {
+            throw new ForbiddenException("Refresh Token Expired");
+        }
+
+        // 쿠키에서 jwt 토큰만 가져옴
+        String refreshTokenJwt = refreshToken.getValue();
+
+        // valid check
+        if(jwtTokenProvider.validateToken(refreshTokenJwt)) {
+            // 토큰으로부터 유저정보를 가져옴.
+            UserDetails userDetails = userDetailsService.loadUserByUsername(jwtTokenProvider.getUserPk(refreshTokenJwt));
+            User user = userRepository.findByEmail(userDetails.getUsername())
+                    .orElseThrow(() -> new IllegalArgumentException("Refresh Token 오류"));
+            /**
+             * redis에 저장되어있는지 체크하는 부분.
+             * redis 설치 후 수정
+             */
+//            String check = redisUtil.getData(refreshTokenJwt);
+//            if(check != null) {
+//                if(check.equals(member.getEmail())) {
+                    // JwtTokenProvider로부터 accessToken 생성
+                    String accessTokenJwt = jwtTokenProvider.createAccessToken(user.getUsername(), user.getRoles());
+                    // 새로운 access 토큰 쿠키를 생성
+                    Cookie newAccessToken = cookieUtil.createCookie("accessToken",
+                            accessTokenJwt, jwtTokenProvider.ACCESS_TOKEN_VALID_TIME, "/");
+                    // http 응답에 실어 보낸다.
+                    res.addCookie(newAccessToken);
+                    // 마지막으로 accessToken을 http body에도 보낸다.
+                    return AccessTokenDto.builder().accessToken(accessTokenJwt).build();
+//                }
+//                redisUtil.deleteData(refreshTokenJwt);
+//            }
+        } else {
+            throw new ForbiddenException("Refresh Token이 유효하지 않습니다.");
         }
     }
 }

--- a/src/main/java/bis/stock/back/domain/auth/AuthService.java
+++ b/src/main/java/bis/stock/back/domain/auth/AuthService.java
@@ -1,0 +1,31 @@
+package bis.stock.back.domain.auth;
+
+import bis.stock.back.domain.auth.dto.JoinDto;
+import bis.stock.back.domain.user.User;
+import bis.stock.back.domain.user.UserRepository;
+import bis.stock.back.domain.user.UserRole;
+import javassist.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+
+    public Long join(JoinDto joinDto) {
+
+        try {
+            return userRepository.save(User.builder()
+                    .email(joinDto.getEmail())
+                    .password(joinDto.getPassword())
+                    .role(UserRole.ROLE_USER)
+                    .build()).getId();
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+}

--- a/src/main/java/bis/stock/back/domain/auth/dto/AccessTokenDto.java
+++ b/src/main/java/bis/stock/back/domain/auth/dto/AccessTokenDto.java
@@ -1,0 +1,9 @@
+package bis.stock.back.domain.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AccessTokenDto {
+
+    private String accessToken;
+}

--- a/src/main/java/bis/stock/back/domain/auth/dto/AccessTokenDto.java
+++ b/src/main/java/bis/stock/back/domain/auth/dto/AccessTokenDto.java
@@ -1,8 +1,12 @@
 package bis.stock.back.domain.auth.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
+@Builder
 public class AccessTokenDto {
 
     private String accessToken;

--- a/src/main/java/bis/stock/back/domain/auth/dto/JoinDto.java
+++ b/src/main/java/bis/stock/back/domain/auth/dto/JoinDto.java
@@ -1,0 +1,11 @@
+package bis.stock.back.domain.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class JoinDto {
+
+    private String email;
+    private String password;
+    private String name;
+}

--- a/src/main/java/bis/stock/back/domain/auth/dto/JoinDto.java
+++ b/src/main/java/bis/stock/back/domain/auth/dto/JoinDto.java
@@ -7,5 +7,5 @@ public class JoinDto {
 
     private String email;
     private String password;
-    private String name;
+    private String nickname;
 }

--- a/src/main/java/bis/stock/back/domain/auth/dto/LoginDto.java
+++ b/src/main/java/bis/stock/back/domain/auth/dto/LoginDto.java
@@ -1,0 +1,10 @@
+package bis.stock.back.domain.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginDto {
+
+    private String email;
+    private String password;
+}

--- a/src/main/java/bis/stock/back/domain/user/User.java
+++ b/src/main/java/bis/stock/back/domain/user/User.java
@@ -12,7 +12,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
-// DB 테이블 생성 테스트용 엔티티 작성
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
@@ -32,40 +31,40 @@ public class User implements UserDetails{
     private String password;
 
     @Column
-    private String username;
+    private String nickname;
 
-//    @Column(name = "created-time")
-//    private LocalDateTime createdTime;
-//
-//    @PrePersist
-//    public void createdAt() {
-//        this.createdTime = LocalDateTime.now();
-//    }
+    @Column(name = "created_time")
+    private LocalDateTime createdTime;
 
+    @PrePersist
+    public void createdAt() {
+        this.createdTime = LocalDateTime.now();
+    }
+
+    @Column
     private Long cash;
 
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Builder.Default
     @Enumerated(EnumType.STRING)
-    private UserRole role;
+    private final List<UserRole> roles = new ArrayList<>();
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        ArrayList<UserRole> roles = new ArrayList<>();
-        roles.add(this.role);
-        return roles.stream().map(UserRole::toString).map(SimpleGrantedAuthority::new).collect(Collectors.toList());
-//        return this.user.getRole().stream()
-//                .map(UserRole::toString)
-//                .map(SimpleGrantedAuthority::new)
-//                .collect(Collectors.toList());
+        return this.roles.stream()
+                .map(UserRole::toString)
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
     }
 
     @Override
     public String getUsername() {
-        return email;
+        return this.email;
     }
 
     @Override
     public String getPassword() {
-        return password;
+        return this.password;
     }
 
     @Override

--- a/src/main/java/bis/stock/back/domain/user/User.java
+++ b/src/main/java/bis/stock/back/domain/user/User.java
@@ -33,12 +33,13 @@ public class User implements UserDetails{
     @Column
     private String nickname;
 
-    @Column(name = "created_time")
-    private LocalDateTime createdTime;
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
 
+    // 생성 시간 저장
     @PrePersist
-    public void createdAt() {
-        this.createdTime = LocalDateTime.now();
+    public void createdAtGenerator() {
+        this.createdAt = LocalDateTime.now();
     }
 
     @Column

--- a/src/main/java/bis/stock/back/domain/user/User.java
+++ b/src/main/java/bis/stock/back/domain/user/User.java
@@ -1,20 +1,90 @@
 package bis.stock.back.domain.user;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 // DB 테이블 생성 테스트용 엔티티 작성
 @NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 @Getter
+@Table(name = "user")
 @Entity
-public class User {
+public class User implements UserDetails{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(unique = true)
+    private String email;
+
+    @Column
+    private String password;
+
+    @Column
+    private String username;
+
+//    @Column(name = "created-time")
+//    private LocalDateTime createdTime;
+//
+//    @PrePersist
+//    public void createdAt() {
+//        this.createdTime = LocalDateTime.now();
+//    }
+
+    private Long cash;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        ArrayList<UserRole> roles = new ArrayList<>();
+        roles.add(this.role);
+        return roles.stream().map(UserRole::toString).map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+//        return this.user.getRole().stream()
+//                .map(UserRole::toString)
+//                .map(SimpleGrantedAuthority::new)
+//                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean  isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/src/main/java/bis/stock/back/domain/user/UserRepository.java
+++ b/src/main/java/bis/stock/back/domain/user/UserRepository.java
@@ -1,0 +1,10 @@
+package bis.stock.back.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/bis/stock/back/domain/user/UserRole.java
+++ b/src/main/java/bis/stock/back/domain/user/UserRole.java
@@ -1,0 +1,5 @@
+package bis.stock.back.domain.user;
+
+public enum UserRole {
+    ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/bis/stock/back/global/config/security/CustomUserDetailService.java
+++ b/src/main/java/bis/stock/back/global/config/security/CustomUserDetailService.java
@@ -1,0 +1,22 @@
+package bis.stock.back.global.config.security;
+
+import bis.stock.back.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        return userRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/bis/stock/back/global/config/security/CustomUserDetailService.java
+++ b/src/main/java/bis/stock/back/global/config/security/CustomUserDetailService.java
@@ -17,6 +17,6 @@ public class CustomUserDetailService implements UserDetailsService {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
         return userRepository.findByEmail(username)
-                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UsernameNotFoundException("cannot found username"));
     }
 }

--- a/src/main/java/bis/stock/back/global/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/bis/stock/back/global/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,35 @@
+package bis.stock.back.global.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilter {
+
+    // GenericFilter를 상속 받아서 Jwt를 이용한 인증 필터 생성
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request,
+                         ServletResponse response,
+                         FilterChain chain) throws IOException, ServletException {
+
+        // 헤더에서 JWT를 받아옴.
+        String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
+        // 유효한 토큰인지 확인함.
+        if(token != null && jwtTokenProvider.validateToken(token)) {
+            // 토큰이 유효하면 토큰으로 부터 유저 정보를 받아옴
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+
+            // SecurityContext 에 Authentication 객체를 저장합니다.
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/bis/stock/back/global/config/security/JwtTokenProvider.java
+++ b/src/main/java/bis/stock/back/global/config/security/JwtTokenProvider.java
@@ -1,0 +1,101 @@
+package bis.stock.back.global.config.security;
+
+import bis.stock.back.domain.user.UserRole;
+import bis.stock.back.global.util.CookieUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class JwtTokenProvider {
+
+    private String secretKey = "beautyinsidestocking";
+
+    // 토큰 유효시간 30분
+    public final Long ACCESS_TOKEN_VALID_TIME = 30 * 60 * 1000L;
+    public final Long REFRESH_TOKEN_VALID_TIME = 60 * 60 * 1000 * 24 * 14L;
+
+    private final UserDetailsService userDetailService;
+    private final CookieUtil cookieUtil;
+
+    @PostConstruct
+    protected void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    public String createAccessToken(String userName, List<UserRole> roles) {
+
+        Claims claims = Jwts.claims().setSubject(userName); // JWT payload에 저장되는 정보 단위
+        claims.put("roles", roles); // 정보는 key / value 쌍으로 저장된다.
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims) // 정보 저장
+                .setIssuedAt(now) // 토큰 발행 시간 정보
+                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_VALID_TIME)) // set Expire time
+                .signWith(SignatureAlgorithm.HS256, secretKey) // 사용할 암호화 알고리즘과
+                // signature 에 들어갈 secret 값 세팅
+                .compact();
+    }
+
+    public String createRefreshToken(String userName, List<UserRole> roles) {
+
+        Claims claims = Jwts.claims().setSubject(userName); // JWT payload에 저장되는 정보 단위
+        claims.put("roles", roles); // 정보는 key / value 쌍으로 저장된다.
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims) // 정보 저장
+                .setIssuedAt(now) // 토큰 발행 시간 정보
+                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_VALID_TIME)) // set Expire time
+                .signWith(SignatureAlgorithm.HS256, secretKey) // 사용할 암호화 알고리즘과
+                // signature 에 들어갈 secret 값 세팅
+                .compact();
+    }
+
+    // JWT 토큰에서 인증 정보 조회
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userDetailService.loadUserByUsername(this.getUserPk(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    // 토큰에서 회원 정보 추출
+    public String getUserPk(String token) {
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        Cookie tokenCookie = cookieUtil.getCookie(request, "accessToken");
+        if(tokenCookie != null) {
+            return tokenCookie.getValue();
+        }
+        return null;
+    }
+
+    // 토큰의 유효성 + 만료일자 확인
+    public boolean validateToken(String jwtToken) {
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken);
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public boolean refreshTokenRedisCheck(String refreshToken) {
+        return true;
+    }
+}

--- a/src/main/java/bis/stock/back/global/config/security/JwtTokenProvider.java
+++ b/src/main/java/bis/stock/back/global/config/security/JwtTokenProvider.java
@@ -55,7 +55,7 @@ public class JwtTokenProvider {
     public String createRefreshToken(String userName, List<UserRole> roles) {
 
         Claims claims = Jwts.claims().setSubject(userName); // JWT payload에 저장되는 정보 단위
-        claims.put("roles", roles); // 정보는 key / value 쌍으로 저장된다.
+        claims.put("role", roles); // 정보는 key / value 쌍으로 저장된다.
         Date now = new Date();
         return Jwts.builder()
                 .setClaims(claims) // 정보 저장

--- a/src/main/java/bis/stock/back/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/bis/stock/back/global/config/security/WebSecurityConfig.java
@@ -41,7 +41,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .authorizeRequests() // 요청에 대해 사용권한 체크
                 .antMatchers("/admin/**").hasRole("ADMIN")
-                .antMatchers("/user/**").hasAnyRole("USER", "ADMIN")
+                .antMatchers("/user/**").hasRole("USER")
                 .anyRequest().permitAll() // 나머지는 누구나 요청 가능 (주식 가격같은 정보는 로그인 안해도 가능)
 
                 .and()

--- a/src/main/java/bis/stock/back/global/config/security/WebSecurityConfig.java
+++ b/src/main/java/bis/stock/back/global/config/security/WebSecurityConfig.java
@@ -1,0 +1,53 @@
+package bis.stock.back.global.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 암호화에 필요한 PasswordEncoder를 Bean 등록함.
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    // authenticationManager를 bean등록
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+
+        http
+                .httpBasic().disable() // rest api 고려해서 기본 설정 해제
+                .csrf().disable() // csrf 보안 토큰 해제
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션은 사용 안하니까 해제
+
+                .and()
+                .authorizeRequests() // 요청에 대해 사용권한 체크
+                .antMatchers("/admin/**").hasRole("ADMIN")
+                .antMatchers("/user/**").hasAnyRole("USER", "ADMIN")
+                .anyRequest().permitAll() // 나머지는 누구나 요청 가능 (주식 가격같은 정보는 로그인 안해도 가능)
+
+                .and()
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class);
+        // JwtAuthenticationFilter를 UsernamePasswordAuthenticationFilter 전에 넣는다
+
+    }
+}

--- a/src/main/java/bis/stock/back/global/exception/ForbiddenException.java
+++ b/src/main/java/bis/stock/back/global/exception/ForbiddenException.java
@@ -1,0 +1,12 @@
+package bis.stock.back.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class ForbiddenException extends RuntimeException{
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/bis/stock/back/global/exception/NotFoundException.java
+++ b/src/main/java/bis/stock/back/global/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package bis.stock.back.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundException extends RuntimeException{
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/bis/stock/back/global/util/CookieUtil.java
+++ b/src/main/java/bis/stock/back/global/util/CookieUtil.java
@@ -1,0 +1,30 @@
+package bis.stock.back.global.util;
+
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+@Service
+public class CookieUtil {
+
+    // 쿠키 생성
+    public Cookie createCookie(String cookieName, String value, Long expireTime, String path) {
+        Cookie token = new Cookie(cookieName, value);
+        token.setHttpOnly(true);
+        token.setMaxAge(Math.toIntExact(expireTime) / 1000);
+        token.setPath(path);
+        return token;
+    }
+
+    // Http 응답으로 부터 쿠키 가져오기
+    public Cookie getCookie(HttpServletRequest req, String cookieName) {
+        final Cookie[] cookies = req.getCookies();
+        if(cookies == null) return null;
+        for(Cookie cookie : cookies) {
+            if(cookie.getName().equals(cookieName))
+                return cookie;
+        }
+        return null;
+    }
+}

--- a/src/main/java/bis/stock/back/global/util/RedisUtil.java
+++ b/src/main/java/bis/stock/back/global/util/RedisUtil.java
@@ -1,0 +1,44 @@
+package bis.stock.back.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class RedisUtil {
+
+    // 문자열로 redis에 serialize, deserialize를 사용하는 템플릿
+    private final StringRedisTemplate stringRedisTemplate;
+
+    // key에 담긴 값 가져오기
+    public String getData(String key) {
+
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        return valueOperations.get(key);
+    }
+
+    // key : value 값 저장하기
+    public void setData(String key, String value) {
+
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        valueOperations.set(key, value);
+    }
+
+    // key : value 에 만료시간까지 지정해서 저장하기
+    public void setDataExpire(String key, String value, long duration) {
+
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    // 값 삭제하기 (만료시간 설정한 값은 굳이 삭제할 필요는 없긴 하지만)
+    public void deleteData(String key) {
+
+        stringRedisTemplate.delete(key);
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,6 +1,10 @@
+# 배포용 profile
 spring:
   datasource:
     url: >
       jdbc:mysql://localhost:3306/stocking?
       useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&
       allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true
+
+  redis:
+    host: localhost

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: >
+      jdbc:mysql://localhost:3306/stocking?
+      useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&
+      allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,12 @@
 spring:
   datasource: #database source 작성
     url: > # localhost 부분 클라우드 ip로 변경. 하지만 배포할 때에는 localhost로 되어 있어야 접근할 수 있음.
-      jdbc:mysql://localhost:3306/stocking?
+      jdbc:mysql://13.209.5.25:3306/stocking?
       useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&
       allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true
     # DB 사용자 아이디와 password 작성
     username: root
-    password: bi1234!@
+    password: 1111
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
     generate-ddl: true
     database: mysql
     hibernate:
-      ddl-auto: create-drop # application 실행 시점에 기존 ddl 정보를 다 지우고 다시 실행시킨다. 그대로 유지하려면 none
+      ddl-auto: update # application 실행 시점에 기존 ddl 정보를 다 지우고 다시 실행시킨다. 그대로 유지하려면 none
     properties:
       hibernate:
         #        show_sql: true # jpa, hibernate가 생성하는 모든 sql이 sout으로 찍힌다

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,12 @@ spring:
     password: 1111
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  cache: # redis 설정
+    type: redis
+  redis:
+    host: 13.209.5.25
+    port: 6379
+
   jpa:
     generate-ddl: true
     database: mysql

--- a/src/test/java/bis/stock/back/global/util/CookieUtilTest.java
+++ b/src/test/java/bis/stock/back/global/util/CookieUtilTest.java
@@ -1,0 +1,54 @@
+package bis.stock.back.global.util;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+import javax.servlet.http.Cookie;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CookieUtilTest {
+
+    @Autowired
+    private CookieUtil cookieUtil;
+
+    private MockHttpServletRequest servletRequest;
+
+    Cookie createTestCookie() {
+        return cookieUtil.createCookie("testCookie",
+                "abc",
+                10L,
+                "/test/cookie");
+    }
+
+    @Test
+    void 쿠키생성() {
+        Cookie cookie = createTestCookie();
+
+        assertThat("testCookie").isEqualTo(cookie.getName());
+        assertThat("abc").isEqualTo(cookie.getValue());
+        assertThat(10/1000).isEqualTo(cookie.getMaxAge());
+        assertThat("/test/cookie").isEqualTo(cookie.getPath());
+    }
+
+    @Test
+    void 쿠키가져오기() {
+        Cookie cookie = createTestCookie();
+        servletRequest = new MockHttpServletRequest();
+        servletRequest.setCookies(cookie);
+
+        assertThat(servletRequest.getCookies()[0].getValue()).isEqualTo(cookie.getValue());
+    }
+}

--- a/src/test/java/bis/stock/back/global/util/RedisUtilTest.java
+++ b/src/test/java/bis/stock/back/global/util/RedisUtilTest.java
@@ -1,0 +1,45 @@
+package bis.stock.back.global.util;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class RedisUtilTest {
+
+    @Autowired
+    private RedisUtil redisUtil;
+
+    @Autowired
+    private RedisTemplate redisTemplate;
+
+    @AfterEach
+    void flush() {
+        redisUtil.deleteData("test");
+    }
+
+    @Test
+    void redis_데이터삭제_조회() {
+        redisUtil.setData("test", "abc");
+        assertThat(redisUtil.getData("test")).isEqualTo("abc");
+    }
+
+    @Test
+    void redis_데이터저장_유효시간() {
+        redisUtil.setDataExpire("test", "abc", 10L);
+        assertThat(redisTemplate.getExpire("test")).isNotNull();
+        assertThat(redisUtil.getData("test")).isEqualTo("abc");
+    }
+
+    @Test
+    void redis_데이터삭제() {
+        redisUtil.setData("test", "abc");
+        redisUtil.deleteData("test");
+        assertThat(redisUtil.getData("test")).isNull();
+    }
+}


### PR DESCRIPTION
### Auth

- 현재 User 모델 개발하였고, 이 모델을 이용해서 로그인, 회원가입, 토큰 재발급 기능 개발
- 토큰은 JWT 기반으로 개발하였고, 30분동안 유효한 Access Token과 14일간 유효한 Refresh Token으로 나누어짐
- 인증이 필요한 대부분의 접근은 Access Token으로 확인하며, Refresh Token은 이 Access Token이 만료되었을 때 재발급만 해주는 용도임.
- Access Token과 Refresh Token은 둘 다 Client의 브라우저에 [HttpOnly](https://jun-itworld.tistory.com/27) 쿠키로 저장됨.
- 추가로 Refresh Token은 서버사이드의 Redis 저장소에 저장하여 유효성 검증을 한 번 더 거침

### 회원가입
```json
{
  "nickname" : "abc",
  "email" : "abc@abc.com",
  "password": "passw0rd"
}
```
`/auth/join`엔드 포인트로 위와 같은 요청(POST)을 보내면 회원 가입이 가능함. (`200`)

이미 저장된 email이라면 `404`응답

### 로그인
```json
{
  "email": "abc@abc.com",
  "password": "passw0rd"
}
```
`/auth/login` 으로 `POST` 요청 보내면 응답으로 Access Token과 Refresh Token이 `HttpOnly`속성이 붙은 쿠키로 발급된다.

추가로 Http Body에도 accessToken이 보내짐

### 재발급
`auth/reissue` 로 `POST` 요청을 보낼 시 Refresh Token의 유효성을 검사한 뒤 위와 같은 방법으로 Access Token만을 발급해 줌.

### 인증 및 인가

`WebSecurityConfig.java`에서 Http 요청이 들어올 때마다 검사하며 특정 엔드포인트로 접근할 시 쿠키에 있는 토큰을 확인하도록 하였다. 

일단 기본적으로 `/admin`은 `ROLE_ADMIN` 권한이 있어야 하고, `/user`은 `ROLE_USER` 권한이 있어야만 접근 가능하다.

이외의 주식 엔드포인트나 각종 다른 부분은 Access Token이 없어도 접근 가능하도록 (로그인이 안되어 있어도) 하였다.

### 테스트 코드

기존에 TDD로 개발을 진행하려고 계획을 했었으나, 깜빡하고 못했음...

일단 지금까지 한 거 빠르게 Merge먼저 하고 나서 현재까지 개발한 부분 테스트 코드 작성 예정임.