### PR TITLE
프로파일 오류 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN ./gradlew bootJar
 FROM openjdk:8-jdk-alpine
 COPY --from=builder build/libs/*.jar app.jar
 
-ARG ENVIRONMENT
+ARG ENVIRONMENT=prod
 ENV SPRING_PROFILES_ACTIVE=${ENVIRONMENT}
 
 EXPOSE 8080
-ENTRYPOINT ["java","-jar","/app.jar","-Dspring.profiles.active=prod"]
+ENTRYPOINT ["java","-jar","/app.jar"]
 
 #RUN ./gradlew build
 #ARG JAR_FILE=build/libs/*.jar

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,25 +1,9 @@
-# 배포용 profile
-spring:
-  profiles: prod
-  datasource:
-    url: >
-      jdbc:mysql://localhost:3306/stocking?
-      useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&
-      allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true
-
-  redis:
-    host: localhost
-
----
-
+# 공통사항들 모아놓음음
 spring:
   profiles:
-    active: default
-  datasource: #database source 작성
-    url: > # localhost 부분 클라우드 ip로 변경. 하지만 배포할 때에는 localhost로 되어 있어야 접근할 수 있음.
-      jdbc:mysql://3.35.51.207:3306/stocking?
-      useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&
-      allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true
+    active: local
+
+  datasource:
     # DB 사용자 아이디와 password 작성
     username: root
     password: 1111
@@ -27,8 +11,6 @@ spring:
 
   cache: # redis 설정
     type: redis
-  redis:
-    host: 3.35.51.207
     port: 6379
 
   jpa:
@@ -41,3 +23,35 @@ spring:
         show_sql: true # jpa, hibernate가 생성하는 모든 sql이 sout으로 찍힌다
         # 운영환경에서는 sout이 아닌 log로 나타내야 한다
         format_sql: true
+---
+
+# 배포용 profile
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: >
+      jdbc:mysql://localhost:3306/stocking?
+      useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&
+      allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true
+
+  redis:
+    host: localhost
+
+---
+# 개발환경용
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource: #database source 작성
+    url: > # localhost 부분 클라우드 ip로 변경. 하지만 배포할 때에는 localhost로 되어 있어야 접근할 수 있음.
+      jdbc:mysql://3.35.51.207:3306/stocking?
+      useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&
+      allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true
+
+  redis:
+    host: 3.35.51.207
+
+---


### PR DESCRIPTION
- Spring boot 2.4 이후부터 application 설정파일의 profile 정책이 바뀌어서 그 부분 수정함.
- 개발환경에서 실행할 시 DB 링크가 클라우드의 IP로 연결되고, docker로 빌드하면 localhost로 연결되도록 수정
- 기존에도 그렇게 했었는데 적용이 안됐던거 같음.