### PR TITLE
API 문서, 테스트 커버리지 추가 및 약간 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## 🔗 Link
 
- - [Stocking RS](http://13.209.5.25:8080/)
+ - [Stocking RS](http://52.78.111.36:8080/)
+
 
 <br>
 
@@ -19,6 +20,8 @@ Stocking 프로젝트 Backend 레포지토리
  - __ER 다이어그램__ : [Stocking ERD](https://www.erdcloud.com/d/ZQjY97KMQrEthMPyn)  
 
  - __스토리보드__ : [카카오오븐](https://ovenapp.io/view/DOhZ6TnDKWFjINtQKjnj2RAulxojOZCb#3QyvB)
+
+ - __API 문서__ : [Swagger](http://52.78.111.36:8080/swagger-ui.html)
 
 <br>
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 	id 'com.google.cloud.tools.jib' version '1.4.0'
+	id 'jacoco'
 }
 
 group = 'bis.stock'
@@ -18,6 +19,20 @@ jib {
       image = "${bootJar.baseName}:${bootJar.version}"
       tags = ['latest']
     }
+}
+
+jacoco {
+	toolVersion = '0.8.7'
+}
+
+jacocoTestReport {
+	reports {
+		html.enabled true
+		html.destination file('build/reports/TestCoverage.html')
+		csv.enabled false
+		xml.enabled false
+
+	}
 }
 
 repositories {
@@ -52,8 +67,13 @@ dependencies {
 	//json사용
 	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1'
 
+	// Swagger API 문서
+	implementation 'io.springfox:springfox-swagger2:2.9.2'
+	implementation 'io.springfox:springfox-swagger-ui:2.9.2'
+
 }
 
 test {
 	useJUnitPlatform()
+	finalizedBy 'jacocoTestReport'
 }

--- a/src/main/java/bis/stock/back/global/config/SwaggerConfig.java
+++ b/src/main/java/bis/stock/back/global/config/SwaggerConfig.java
@@ -1,0 +1,53 @@
+package bis.stock.back.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("Stocking")
+                .description("Stocking 프로젝트 API 문서")
+                .version("1.0")
+                .build();
+   }
+
+   private Set<String> getConsumeContentTypes() {
+        Set<String> consumes = new HashSet<>();
+        consumes.add("application/json;charset=UTF-8");
+        consumes.add("application/x-www-form-urlencoded");
+        return consumes;
+   }
+
+   private Set<String> getProduceContentTypes() {
+        Set<String> produces = new HashSet<>();
+        produces.add("application/json;charset=UTF-8");
+        return produces;
+   }
+
+   @Bean
+   public Docket commonApi() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .consumes(getConsumeContentTypes())
+                .produces(getProduceContentTypes())
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
+                .paths(PathSelectors.any())
+                .build();
+   }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,4 @@
-# 공통사항들 모아놓음음
+# 공통사항들 모아놓음
 spring:
   profiles:
     active: local
@@ -12,6 +12,9 @@ spring:
   cache: # redis 설정
     type: redis
     port: 6379
+
+  redis:
+    host: 34.83.181.251
 
   jpa:
     generate-ddl: true
@@ -36,9 +39,6 @@ spring:
       useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&
       allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true
 
-  redis:
-    host: localhost
-
 ---
 # 개발환경용
 spring:
@@ -47,11 +47,8 @@ spring:
       on-profile: local
   datasource: #database source 작성
     url: > # localhost 부분 클라우드 ip로 변경. 하지만 배포할 때에는 localhost로 되어 있어야 접근할 수 있음.
-      jdbc:mysql://3.35.51.207:3306/stocking?
+      jdbc:mysql://52.78.111.36:3306/stocking?
       useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&
       allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true
-
-  redis:
-    host: 3.35.51.207
 
 ---


### PR DESCRIPTION
### API 문서

- `Swagger`를 이용해서 API 문서화 추가하였음.
- 서버 실행시키고 `/swagger-ui.html` 로 접속하면 API 문서 확인 가능합니다.

### 코드 커버리지

- `jacoco` 추가
- 프로젝트 디렉토리에서 `./gradlew test` 실행하면 테스트 실행하고 커버리지 생성함
- 테스트 커버리지는 `./build/reports/TestCoverage.html/index.html`로 확인 가능합니다.

### 수정 사항

- AWS가 또 맛이 가서 Redis는 다른 클라우드에서 돌려서 연동함. (Google Cloud Platform)
- 그리고 IP도 바뀌었길래 그 부분 살짝 고침.

### 코드 리뷰

- API 문서 만들어진걸 보니까 몇 개 눈에 띄는게 있어서 추가해봅니다.
- @yoonwooseong `asset` 기능에서 엔드포인트가 `asset/asset/deposit/~` 이렇게 asset이 두 번 나옴
- @yujin0131 컨트롤러 부분에 각 메소드에서 HTTP 메소드를 지정 해줘야 할 것 같습니다. 예를 들면
```java
   @ResponseBody
   @RequestMapping(value="/detail")    //이 부분이 `@GetMapping`이나 `@PostMapping`과 같은 형태가 되어야 하는걸로 알고있음
   public String detail(@RequestParam(value="itemname", defaultValue="삼성전자") String itemname, RedirectAttributes redirect) {

      String itemcode = stockService.findcode(itemname);

      try {
         itemcode = String.format("%06d", Integer.parseInt(itemcode)).toString();
      } catch (Exception e) {

      }

      return stockService.detail(itemcode, itemname);
   }

```
- 또 의존성 주입 부분에서 `AutoWired`를 사용했는데, [여기](https://madplay.github.io/post/why-constructor-injection-is-better-than-field-injection) 한 번 읽어보시면 도움 될 듯. 
- 롬복을 이용해서 `@RequiredArgsConstructor` 어노테이션을 클래스에 추가하고 `private final StockService stockService`와 같은 방식으로 사용하면 편함

나도 코드에서 수정해야 할 부분 있으면 코드 리뷰 부탁드립니다.