### PR TITLE
DB 커넥션 에러 FIX

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,10 +34,10 @@ spring:
     activate:
       on-profile: prod
   datasource:
-    url: >
-      jdbc:mysql://localhost:3306/stocking?
+    url: > # localhost나 127.0.0.1이 아닌 도커 컨테이너 이름으로 설정해야 한다고 함...
+      jdbc:mysql://mysql:3306/stocking?
       useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&
-      allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true
+      allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true&autoReconnection=true
 
 ---
 # 개발환경용
@@ -49,6 +49,6 @@ spring:
     url: > # localhost 부분 클라우드 ip로 변경. 하지만 배포할 때에는 localhost로 되어 있어야 접근할 수 있음.
       jdbc:mysql://52.78.111.36:3306/stocking?
       useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&
-      allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true
+      allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true&autoReconnection=true
 
 ---


### PR DESCRIPTION
기존에 DB url을 localhost나 127.0.0.1로 설정하고 배포했었는데, 이 부분에서 자꾸 오류가 났던 것 같음.

외부에서 클라우드 ip를 지정해서 들어갈 때는 문제가 없는데, 내부에서는 각 컨테이너가 별도의 내부 ip를 동적으로 생성하다 보니 localhost라고 지정하면 서로 다른 컨테이너가 연결이 안됐던 것...

그래서 컨테이너끼리 연결할 떄에는 `application.yml`의 datasource url 부분에 **db 컨테이너의 이름**을 넣어준 뒤, 백엔드 컨테이너 실행시킬때 `--link <db 컨테이너 이름>` 을 꼭 넣어줘야 한다.

예시)

``` yml
# application.yml
spring:
  datasource:
    url:  jdbc:mysql://mysql:3306/stocking?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC

# 실행시킬 때
docker run -d -p 8080:8080 --link mysql stocking-back:latest
```

이제 http://52.78.111.36:8080/swagger-ui.html#/ 들어가보면 API 문서 확인 가능.

참고로 저 Swagger 문서에 별도 설명(한글)을 붙일 수 있으니 추가하고 싶은 마음이 있으면 검색해보세요.