### PR TITLE
주식 API 업데이트 및 배포환경 수정

### DIFF
--- a/src/main/java/bis/stock/back/domain/stock/StockController.java
+++ b/src/main/java/bis/stock/back/domain/stock/StockController.java
@@ -41,7 +41,7 @@ public class StockController {
       return stockService.detail(itemCode, itemName);
    }
 
-   // ...:8080/stock/005930
+   // ...:8080/stock/005930 (Item code)
    @GetMapping("/{code}")
    public ResponseEntity<Stock> getStockByCode(@PathVariable String code) {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,4 @@
 # 공통사항들 모아놓음
-
 spring:
   # TODO : 기본적으로 Http exeption의 메세지를 표시하지 않도록 되어있음. (보안 문제) 메세지는 표시되도록 풀어주기
   server:
@@ -19,7 +18,6 @@ spring:
     type: redis
     port: 6379
 
-
   jpa:
     generate-ddl: true
     database: mysql
@@ -31,7 +29,6 @@ spring:
         # 운영환경에서는 sout이 아닌 log로 나타내야 한다
         format_sql: true
 ---
-
 # 배포용 profile
 spring:
   redis:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
       ddl-auto: update # application 실행 시점에 기존 ddl 정보를 다 지우고 다시 실행시킨다. 그대로 유지하려면 none
     properties:
       hibernate:
-        show_sql: true # jpa, hibernate가 생성하는 모든 sql이 sout으로 찍힌다
+        # show_sql: true # jpa, hibernate가 생성하는 모든 sql이 sout으로 찍힌다
         # 운영환경에서는 sout이 아닌 log로 나타내야 한다
         format_sql: true
 ---
@@ -46,14 +46,17 @@ spring:
       allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true&autoReconnection=true
 
 ---
+# TODO : docker-compose를 이용해서 컨테이너 설정하고, datasource 설정 다시하기
 # 개발환경용
+# 146.56.100.95 - oracle
+# 52.78.111.36 - 우성이 aws
 spring:
   config:
     activate:
       on-profile: local
   datasource: #database source 작성
     url: > # localhost 부분 클라우드 ip로 변경. 하지만 배포할 때에는 localhost로 되어 있어야 접근할 수 있음.
-      jdbc:mysql://52.78.111.36:3306/stocking?
+      jdbc:mysql://146.56.100.95:3306/stocking?
       useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&
       allowPublicKeyRetrieval=true&createDatabaseIfNotExist=true&autoReconnection=true
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,11 @@
 # 공통사항들 모아놓음
+
 spring:
+  # TODO : 기본적으로 Http exeption의 메세지를 표시하지 않도록 되어있음. (보안 문제) 메세지는 표시되도록 풀어주기
+  server:
+    error:
+      include-message: true
+
   profiles:
     active: local
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,6 @@ spring:
     type: redis
     port: 6379
 
-  redis:
-    host: 34.83.181.251
 
   jpa:
     generate-ddl: true
@@ -36,6 +34,8 @@ spring:
 
 # 배포용 profile
 spring:
+  redis:
+    host: redis
   config:
     activate:
       on-profile: prod
@@ -51,6 +51,8 @@ spring:
 # 146.56.100.95 - oracle
 # 52.78.111.36 - 우성이 aws
 spring:
+  redis:
+    host: 146.56.100.95
   config:
     activate:
       on-profile: local


### PR DESCRIPTION
주식 가격을 객체로 관리하고, 각 주식과 주식 가격 객체를 1:1 매핑하여 관리함.

주식 가격은 장 중에만 업데이트 하도록 설정하고, 장이 끝나면 더 이상 업데이트를 하지 않도록 하여 주식 API에 보내는 트래픽을 최소화하였음.

또 배포 및 운영환경이 여러 곳으로 분리되어 있었는데, 관리의 용이성을 위하여 내(상근) 클라우드로 설정하려고 함.